### PR TITLE
Create memo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docker-compose.yml
 breath.yml
+*.yml
 *.conf
 elm-stuff

--- a/docker/memo_app/Makefile
+++ b/docker/memo_app/Makefile
@@ -1,0 +1,9 @@
+
+develop: docker-compose-develop.yml
+	docker-compose -f docker-compose-develop.yml up --build
+
+release: docker-compose.yml
+	docker-compose -f docker-compose.yml up --build
+
+sh:
+	docker run -it memo_app_api_server /bin/ash

--- a/docker/memo_app/api_server/Dockerfile
+++ b/docker/memo_app/api_server/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:alpine
+
+USER root
+
+COPY ./go/src/memo_app /go/src/memo_app
+WORKDIR /go/src/memo_app
+RUN go build -o main
+RUN mkdir /app \
+  && cp /go/src/memo_app/main /app/main
+
+WORKDIR /
+CMD ./app/main

--- a/docker/memo_app/api_server/go/src/memo_app/go.mod
+++ b/docker/memo_app/api_server/go/src/memo_app/go.mod
@@ -1,0 +1,3 @@
+module github.com/wsuzume/base_project/memo_app
+
+go 1.13

--- a/docker/memo_app/api_server/go/src/memo_app/main.go
+++ b/docker/memo_app/api_server/go/src/memo_app/main.go
@@ -1,0 +1,7 @@
+package main
+
+
+func main() {
+	println("Hello, world!!")
+	return
+}

--- a/docker/memo_app/docker-compose-develop.breath
+++ b/docker/memo_app/docker-compose-develop.breath
@@ -1,0 +1,41 @@
+version: "3"
+
+services:
+  memo_app_mysql:
+    build: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: {{{MYSQL_ROOT_PASSWORD}}}
+      MYSQL_DATABASE: {{{MYSQL_DATABASE}}}
+      MYSQL_USER: {{{MYSQL_USER}}}
+      MYSQL_PASSWORD: {{{MYSQL_PASSWORD}}}
+      TZ: 'Asia/Tokyo'
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - ./mysql/data:/var/lib/mysql
+      - ./mysql/conf.d:/etc/mysql/conf.d
+      - ./mysql/initdb.d:/docker-entrypoint-initdb.d
+    ports:
+      - 3306:3306
+
+  memo_app_redis:
+    build: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - "./redis/data:/data"
+    sysctls:
+      - net.core.somaxconn=1024
+# This setting can be enabled if Docker host's global kernel parameter is vm.overcomiit_memory=1
+# Consider `sysctl vm.overcommit_memory=1 on your host.`
+#      - vm.overcommit_memory=1
+
+  api_server:
+    build: api_server
+    depends_on:
+      - memo_app_mysql
+      - memo_app_redis
+    volumes:
+      - ./api_server/go/src/memo_app:/go/src/memo_app
+    ports:
+      - "8080:8080"
+

--- a/docker/memo_app/docker-compose-develop.breath
+++ b/docker/memo_app/docker-compose-develop.breath
@@ -3,6 +3,7 @@ version: "3"
 services:
   memo_app_mysql:
     build: mysql
+    container_name: memo_app_mysql
     environment:
       MYSQL_ROOT_PASSWORD: {{{MYSQL_ROOT_PASSWORD}}}
       MYSQL_DATABASE: {{{MYSQL_DATABASE}}}
@@ -12,7 +13,7 @@ services:
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - ./mysql/data:/var/lib/mysql
-      - ./mysql/conf.d:/etc/mysql/conf.d
+      - ./mysql/conf.d:/etc/mysql
       - ./mysql/initdb.d:/docker-entrypoint-initdb.d
     ports:
       - 3306:3306

--- a/docker/memo_app/mysql/Dockerfile
+++ b/docker/memo_app/mysql/Dockerfile
@@ -1,0 +1,6 @@
+FROM mysql:8.0.17
+
+# VOLUME としてマウントしているので以下の chmod は動作しない
+# Warning を消すには必要なので後で対応を考える
+#RUN mkdir -p /var/lib/mysql
+#RUN chmod 770 /var/lib/mysql

--- a/docker/memo_app/mysql/conf.d/my.cnf
+++ b/docker/memo_app/mysql/conf.d/my.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+datadir=/var/lib/mysql

--- a/docker/memo_app/mysql/conf.d/my.cnf
+++ b/docker/memo_app/mysql/conf.d/my.cnf
@@ -1,2 +1,3 @@
 [mysqld]
 datadir=/var/lib/mysql
+secure_file_priv=/var/lib/mysql


### PR DESCRIPTION
golang のAPIサーバー用コンテナおよび MySQL と Redis のコンテナが起動。

Redis の Transparent Huge Pages (THP) の Warning は https://github.com/docker-library/redis/issues/19 を見た限りではよっぽどのことがない限りいじるべきではなさそう（`vm.overcommit_memory`はDockerホストのカーネルパラメータが引き継がれるので変更するとシステム全体に影響が及ぶ）。

MySQLの`[Warning] [MY-010101] [Server] Insecure configuration for --secure-file-priv: Location is accessible to all OS users. Consider choosing a different directory.`も、Dockerホストのディレクトリをボリュームとしてマウントしたディレクトリを使用しているため、`chmod`が利かない。現時点ではあまり問題視していないが、ゆくゆくはなんとかしたい。

MySQLの`[Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.`も、まず暗号化せずに通信できるか試したいので後回し。手前にリバースプロキシがあること前提なのであまり有効化する意義も感じないが、やるとしてもAPIサーバー側からは https://github.com/go-sql-driver/mysql/blob/master/utils.go#L58 でOpen前に設定すればいいだけなのでそんな手間ではないはず。